### PR TITLE
wrap value passed to OpenBLAS build options in single quotes

### DIFF
--- a/easybuild/easyblocks/o/openblas.py
+++ b/easybuild/easyblocks/o/openblas.py
@@ -28,7 +28,7 @@ class EB_OpenBLAS(ConfigureMake):
         for key in sorted(default_opts.keys()):
             for opts_key in ['buildopts', 'installopts']:
                 if '%s=' % key not in self.cfg[opts_key]:
-                    self.cfg.update(opts_key, '%s=%s' % (key, default_opts[key]))
+                    self.cfg.update(opts_key, "%s='%s'" % (key, default_opts[key]))
 
         self.cfg.update('installopts', 'PREFIX=%s' % self.installdir)
 


### PR DESCRIPTION
@edmondac Values for `$CC` and `$FC` could (in theory) have spaces in them, so better safe than sorry and wrap all values in quotes...