### PR TITLE
Correct mpi flag to configure

### DIFF
--- a/easybuild/easyblocks/m/mrbayes.py
+++ b/easybuild/easyblocks/m/mrbayes.py
@@ -78,7 +78,10 @@ class EB_MrBayes(ConfigureMake):
                 raise EasyBuildError("beagle-lib module not loaded?")
 
             if self.toolchain.options.get('usempi', None):
-                self.cfg.update('configopts', '--enable-mpi')
+                if LooseVersion(self.version) < LooseVersion("3.2.7"):
+                    self.cfg.update('configopts', '--enable-mpi')
+                else:
+                    self.cfg.update('configopts', '--with-mpi')
 
             # configure
             super(EB_MrBayes, self).configure_step()


### PR DESCRIPTION
MrBayes install procedure has changed quite a bit between 3.2.6 and 3.2.7a... including changing configure flags...